### PR TITLE
Replace magit-insert with insert

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -645,7 +645,7 @@ Use ARGS to pass additional arguments."
                                                  state)))))
         (insert (propertize empty 'face 'magit-stgit-empty) ?\s)
         (when magit-stgit-show-patch-name
-          (magit-insert patch 'magit-stgit-patch ?\s))
+          (insert (propertize patch 'face 'magit-stgit-patch) ?\s))
         (insert msg)
         (put-text-property (line-beginning-position) (1+ (line-end-position))
                            'keymap 'magit-stgit-patch-map)


### PR DESCRIPTION
Because magit-insert is no longer available.

https://github.com/magit/magit-stgit/commit/0130845f2e0001ad695a9078a187463fde1a58ba did not replace all `magit-insert`.