### PR TITLE
Add --edit-cover switch to stg mail popup

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -549,6 +549,7 @@ Use ARGS to pass additional arguments."
   :man-page "stg-mail"
   :switches '((?m "Generate an mbox file instead of sending" "--mbox")
               (?g "Use git send-email" "--git" t)
+              (?e "Edit cover letter before send" "--edit-cover")
               (?A "Auto-detect To, Cc and Bcc for all patches from cover"
                   "--auto-recipients" t))
   :options '((?o "Set file as cover message" "--cover="


### PR DESCRIPTION
This is useful for having stgit generate the template instead of supplying a full formatted file.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>