### PR TITLE
Add --auto switch to mail popup

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -550,6 +550,7 @@ Use ARGS to pass additional arguments."
   :switches '((?m "Generate an mbox file instead of sending" "--mbox")
               (?g "Use git send-email" "--git" t)
               (?e "Edit cover letter before send" "--edit-cover")
+              (?a "Auto-detect recipients for each patch" "--auto")
               (?A "Auto-detect To, Cc and Bcc for all patches from cover"
                   "--auto-recipients" t))
   :options '((?o "Set file as cover message" "--cover="


### PR DESCRIPTION
The --auto switch causes stg to parse tags in each commit message and add
recipients from them to that mail only. This is distinct from the
--auto-recipients switch already present, and is useful for, e.g., Cc'ing
subsets of a patch series to people not interested in the full series.

Signed-off-by: Toke Høiland-Jørgensen <toke@toke.dk>