### PR TITLE
Switch from dash to llama and other refreshes

### DIFF
--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -140,7 +140,7 @@
 (defun magit-run-stgit (&rest args)
   "Run StGit command with given arguments.
 Any list in ARGS is flattened."
-  (magit-run-stgit-callback (lambda ()) args))
+  (magit-run-stgit-callback nil args))
 
 (defun magit-run-stgit-async (&rest args)
   "Asynchronously run StGit command with given arguments.
@@ -162,7 +162,8 @@ Argument PATCHES sets the marks to remove, and ARGS the arguments to StGit."
 Function CALLBACK will be executed before refreshing the buffer.
 Any list in ARGS is flattened."
   (apply #'magit-call-process magit-stgit-executable (-flatten args))
-  (funcall callback)
+  (when callback
+    (funcall callback))
   (magit-refresh))
 
 (defun magit-stgit-lines (&rest args)

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -8,7 +8,10 @@
 ;; Keywords: git tools vc
 
 ;; Package: magit-stgit
-;; Package-Requires: ((emacs "24.4") (magit "2.12.0") (transient "0.3.7"))
+;; Package-Requires: (
+;;     (emacs "27.1")
+;;     (magit "4.3.0")
+;;     (transient "0.8.4"))
 
 ;; SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -10,6 +10,7 @@
 ;; Package: magit-stgit
 ;; Package-Requires: (
 ;;     (emacs "27.1")
+;;     (llama "0.6.0")
 ;;     (magit "4.3.0")
 ;;     (transient "0.8.4"))
 
@@ -65,6 +66,7 @@
 
 (require 'cl-lib)
 (require 'dash)
+(require 'llama)
 
 (require 'magit)
 (require 'transient)
@@ -152,7 +154,7 @@ Any list in ARGS is flattened."
 (defun magit-run-stgit-and-mark-remove (patches &rest args)
   "Run `magit-run-stgit' and `magit-stgit-mark-remove'.
 Argument PATCHES sets the marks to remove, and ARGS the arguments to StGit."
-  (magit-run-stgit-callback (lambda () (magit-stgit-mark-remove patches)) args))
+  (magit-run-stgit-callback (##magit-stgit-mark-remove patches) args))
 
 (defun magit-run-stgit-callback (callback &rest args)
   "Run StGit command with given arguments.
@@ -584,7 +586,7 @@ one from the minibuffer. Ask whether to spill the contents and
 ask for confirmation before deleting."
   (interactive (cons (magit-stgit-read-patches t t t t "Delete patch")
                      (transient-args 'magit-stgit-delete)))
-  (let* ((non-empty-p (-some (-cut magit-stgit-lines "files" "--bare" <>)
+  (let* ((non-empty-p (-some (##magit-stgit-lines "files" "--bare" %)
                              patches))
          (args (if (and (called-interactively-p 'any)
                         (not transient-current-prefix)
@@ -598,8 +600,7 @@ ask for confirmation before deleting."
                (format "Delete%s patch%s %s? "
                        (if spillp " and spill" "")
                        (if (> (length patches) 1) "es" "")
-                       (mapconcat (lambda (patch) (format "`%s'" patch))
-                        patches ", "))))
+                       (mapconcat (##format "`%s'" %) patches ", "))))
       (magit-run-stgit-and-mark-remove patches "delete" args patches))))
 
 (transient-define-prefix magit-stgit-goto ()

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -826,7 +826,7 @@ one from the minibuffer."
 (defun magit-stgit-wash-patch ()
   (when (looking-at magit-stgit-patch-re)
     (magit-bind-match-strings (empty state patch msg) nil
-      (delete-region (point) (point-at-eol))
+      (delete-region (point) (line-end-position))
       (magit-insert-section (stgit-patch patch)
         (insert (if (magit-stgit-mark-contains patch) "#" " "))
         (insert (propertize state 'face

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -7,7 +7,6 @@
 ;; Homepage: https://github.com/stacked-git/magit-stgit
 ;; Keywords: git tools vc
 
-;; Package: magit-stgit
 ;; Package-Requires: (
 ;;     (emacs "27.1")
 ;;     (llama "0.6.0")

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -180,8 +180,8 @@ Any list in ARGS is flattened."
 
 (defun magit-stgit-patches-sorted (patches)
   "Return elements in PATCHES with the same partial order as the series."
-  (mapcan (lambda (patch) (and (member patch patches) (list patch)))
-          (magit-stgit-lines "series" "--noprefix")))
+  (seq-keep (##car (member % patches))
+            (magit-stgit-lines "series" "--noprefix")))
 
 ;;; Marking
 

--- a/magit-stgit.el
+++ b/magit-stgit.el
@@ -1,6 +1,6 @@
 ;;; magit-stgit.el --- StGit extension for Magit  -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2011-2023  The Magit Project Contributors
+;; Copyright (C) 2011-2025  The Magit Project Contributors
 
 ;; Author: Lluís Vilanova <vilanova@ac.upc.edu>
 ;; Maintainer: Peter Grayson <pete@jpgrayson.net>


### PR DESCRIPTION
This includes the commits from #18.  LLama is added before those commits before it affects one of them.  Also the first is modified to use `(append ... nil)` instead of the internal `seq--into-list`, which shouldn't be used outside of `seq.el`.